### PR TITLE
Fixes for the java generator

### DIFF
--- a/src/cloop/Generator.cpp
+++ b/src/cloop/Generator.cpp
@@ -1514,7 +1514,7 @@ void JnaGenerator::generate()
 		fprintf(out, "\n");
 		fprintf(out, "\t{\n");
 
-		//// TODO: version
+		fprintf(out, "\t\tpublic int VERSION = %u;\n\n", interface->version);
 
 		for (vector<Constant*>::iterator j = interface->constants.begin();
 			 j != interface->constants.end();
@@ -1633,7 +1633,7 @@ void JnaGenerator::generate()
 		if (!interface->super)
 		{
 			fprintf(out, "\t\t\tpublic com.sun.jna.Pointer cloopDummy;\n");
-			fprintf(out, "\t\t\tpublic com.sun.jna.Pointer version;\n");
+			fprintf(out, "\t\t\tpublic int version;\n");
 			fprintf(out, "\n");
 		}
 
@@ -1905,6 +1905,22 @@ void JnaGenerator::generate()
 			fprintf(out, "\t\t{\n");
 			fprintf(out, "\t\t\tVTable vTable = getVTable();\n");
 
+			fprintf(out, "\t\t\tif (vTable.%s == null) {\n", escapeName(method->name).c_str());
+			if (method->parameters.size() > 0 && method->parameters[0]->name == "status" && method->parameters[0]->typeRef.type == BaseType::TYPE_INTERFACE &&
+				method->parameters[0]->typeRef.token.type == Token::TYPE_IDENTIFIER)
+				fprintf(out, "\t\t\t\t%s.setVersionError(status, this.getClass().getName(), vTable.version, I%sIntf.VERSION);\n", exceptionClass.c_str(), escapeName(interface->name).c_str());
+			if (method->returnTypeRef.token.type != Token::TYPE_VOID ||
+				method->returnTypeRef.isPointer)
+			{
+				fprintf(out, "\t\t\t\treturn %s;\n",
+					literalForError(method->returnTypeRef).c_str());
+			} 
+			else
+			{
+				fprintf(out, "\t\t\t\treturn;\n");
+			}
+
+			fprintf(out, "\t\t\t}\n");
 			fprintf(out, "\t\t\t");
 
 			if (method->returnTypeRef.token.type != Token::TYPE_VOID ||

--- a/src/cloop/Generator.h
+++ b/src/cloop/Generator.h
@@ -150,13 +150,14 @@ class JnaGenerator : public FileGenerator
 {
 public:
 	JnaGenerator(const std::string& filename, const std::string& prefix, Parser* parser,
-		const std::string& className, const std::string& exceptionClass);
+		const std::string& className, const std::string& exceptionClass,
+		const std::string& extendLibrary);
 
 public:
 	virtual void generate();
 
 private:
-	std::string convertType(const TypeRef& typeRef, bool forReturn);
+	std::string convertType(const TypeRef& typeRef, bool forReturn, bool eventCallback);
 	std::string literalForError(const TypeRef& typeRef);
 	std::string escapeName(const std::string& name);
 
@@ -164,6 +165,7 @@ private:
 	Parser* parser;
 	std::string className;
 	std::string exceptionClass;
+	std::string extendLibrary;
 };
 
 

--- a/src/cloop/Main.cpp
+++ b/src/cloop/Main.cpp
@@ -138,7 +138,11 @@ static void run(int argc, const char* argv[])
 		string exceptionClass(argv[5]);
 		string prefix(argv[6]);
 
-		generator.reset(new JnaGenerator(outFilename, prefix, &parser, className, exceptionClass));
+		string extendLibrary;
+		if (argc == 8)
+			extendLibrary = argv[7];
+
+		generator.reset(new JnaGenerator(outFilename, prefix, &parser, className, exceptionClass, extendLibrary));
 	}
 	else if (outFormat == "json")
 		generator.reset(new JsonGenerator(outFilename, &parser));


### PR DESCRIPTION
1. Allow specifying library to extend.
2. Using com.sun.jna.Pointer for integer arrays and event callbacks.
3. Using com.sun.jna.ptr.LongByReference for ISC_QUAD, isc_stmt_handle and isc_tr_handle.